### PR TITLE
Add configuration to offset window position (X, Y)

### DIFF
--- a/WinTermPlus/App.config
+++ b/WinTermPlus/App.config
@@ -22,6 +22,12 @@
             <setting name="Width" serializeAs="String">
                 <value>80</value>
             </setting>
+            <setting name="PositionX" serializeAs="String">
+                <value>0</value>
+            </setting>
+            <setting name="PositionY" serializeAs="String">
+                <value>0</value>
+            </setting>
         </WinTermPlus.Properties.Settings>
     </userSettings>
 </configuration>

--- a/WinTermPlus/Config.cs
+++ b/WinTermPlus/Config.cs
@@ -5,6 +5,7 @@ namespace WinTermPlus
     public class Config
     {
         public WindowSize Size => new WindowSize(new Percentage(Width), new Percentage(Height));
+        public WindowPosition Position => new WindowPosition(PositionX, PositionY);
 
         public bool QuakeMode
         {
@@ -32,6 +33,26 @@ namespace WinTermPlus
             set
             {
                 Properties.Settings.Default.Width = value; 
+                Save();
+            }
+        }
+
+        public int PositionX
+        {
+            get => Properties.Settings.Default.PositionX;
+            set
+            {
+                Properties.Settings.Default.PositionX = value;
+                Save();
+            }
+        }
+
+        public int PositionY
+        {
+            get => Properties.Settings.Default.PositionY;
+            set
+            {
+                Properties.Settings.Default.PositionY = value;
                 Save();
             }
         }

--- a/WinTermPlus/Infrastructure/WindowPosition.cs
+++ b/WinTermPlus/Infrastructure/WindowPosition.cs
@@ -1,0 +1,15 @@
+﻿namespace WinTermPlus.Infrastructure
+{
+    public class WindowPosition
+    {
+        private WindowPosition() { }
+        public WindowPosition(int x, int y)
+        {
+            X = x;
+            Y = y;
+        }
+
+        public int X { get; }
+        public int Y { get; }
+    }
+}

--- a/WinTermPlus/Interop/WindowsTerminalProcess.cs
+++ b/WinTermPlus/Interop/WindowsTerminalProcess.cs
@@ -46,7 +46,7 @@ namespace WinTermPlus.Interop
             return true;
         }
 
-        public void ToggleVisibility(WindowSize size)
+        public void ToggleVisibility(WindowSize size, WindowPosition position)
         {
             if (IsFocused)
             {
@@ -54,17 +54,17 @@ namespace WinTermPlus.Interop
             }
             else
             {
-                Show(size);
+                Show(size, position);
             }
         }
 
-        public void Show(WindowSize size)
+        public void Show(WindowSize size, WindowPosition position)
         {
             RunOnHandle(handle =>
             {
                 PInvoke.ShowWindow(handle, ShowWindowCommands.Restore);
                 PInvoke.SetForegroundWindow(handle);
-                ResizeAndPositionWindow(handle, size);
+                ResizeAndPositionWindow(handle, size, position);
             });
         }
 
@@ -75,14 +75,13 @@ namespace WinTermPlus.Interop
             );
         }
 
-        private void ResizeAndPositionWindow(IntPtr handle, WindowSize size)
+        private void ResizeAndPositionWindow(IntPtr handle, WindowSize size, WindowPosition windowPosition)
         {
             var primaryScreenBounds = Screen.PrimaryScreen.Bounds;
             var width = (int)Math.Floor(primaryScreenBounds.Width * size.Width.ToDouble());
-            var x = (primaryScreenBounds.Width - width) / 2;
             var height = (int)Math.Floor(primaryScreenBounds.Height * size.Height.ToDouble());
 
-            PInvoke.MoveWindow(handle, x, 0, width, height, true);
+            PInvoke.MoveWindow(handle, windowPosition.X, windowPosition.Y, width, height, true);
         }
 
         public static WindowsTerminalProcess Get()
@@ -107,9 +106,9 @@ namespace WinTermPlus.Interop
             return new WindowsTerminalProcess(process);
         }
 
-        public void ResizeAndPositionWindow(WindowSize windowSize)
+        public void ResizeAndPositionWindow(WindowSize windowSize, WindowPosition windowPosition)
         {
-            RunOnHandle(handle => ResizeAndPositionWindow(handle, windowSize));
+            RunOnHandle(handle => ResizeAndPositionWindow(handle, windowSize, windowPosition));
         }
     }
 }

--- a/WinTermPlus/Properties/Settings.Designer.cs
+++ b/WinTermPlus/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace WinTermPlus.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.3.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.4.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -68,6 +68,30 @@ namespace WinTermPlus.Properties {
             }
             set {
                 this["Width"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0")]
+        public int PositionX {
+            get {
+                return ((int)(this["PositionX"]));
+            }
+            set {
+                this["PositionX"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0")]
+        public int PositionY {
+            get {
+                return ((int)(this["PositionY"]));
+            }
+            set {
+                this["PositionY"] = value;
             }
         }
     }

--- a/WinTermPlus/Properties/Settings.settings
+++ b/WinTermPlus/Properties/Settings.settings
@@ -14,5 +14,11 @@
     <Setting Name="Width" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">80</Value>
     </Setting>
+    <Setting Name="PositionX" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">0</Value>
+    </Setting>
+    <Setting Name="PositionY" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">0</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/WinTermPlus/UI/ViewModels/ConfigViewModel.cs
+++ b/WinTermPlus/UI/ViewModels/ConfigViewModel.cs
@@ -43,6 +43,27 @@ namespace WinTermPlus.UI.ViewModels
                 NotifyOfPropertyChange(nameof(Height));
             }
         }
+
+        public int PositionX
+        {
+            get => _config.PositionX;
+            set
+            {
+                _config.PositionX = value;
+                NotifyOfPropertyChange(nameof(PositionX));
+            }
+        }
+
+        public int PositionY
+        {
+            get => _config.PositionY;
+            set
+            {
+                _config.PositionY = value;
+                NotifyOfPropertyChange(nameof(PositionY));
+            }
+        }
+
         public bool StartWithWindows
         {
             get => _config.StartWithWindows;
@@ -59,7 +80,7 @@ namespace WinTermPlus.UI.ViewModels
             base.NotifyOfPropertyChange(propertyName);
 
             var process = WindowsTerminalProcess.Get();
-            process?.ResizeAndPositionWindow(_config.Size);
+            process?.ResizeAndPositionWindow(_config.Size, _config.Position);
         }
 
         public void Done()

--- a/WinTermPlus/UI/ViewModels/ShellViewModel.cs
+++ b/WinTermPlus/UI/ViewModels/ShellViewModel.cs
@@ -40,11 +40,11 @@ namespace WinTermPlus.UI.ViewModels
             if(windowsTerminalProcess == null)
             {
                 windowsTerminalProcess = WindowsTerminalProcess.Launch();
-                windowsTerminalProcess.Show(_settings.Size);
+                windowsTerminalProcess.Show(_settings.Size, _settings.Position);
             }
             else
             {
-                windowsTerminalProcess.ToggleVisibility(_settings.Size);
+                windowsTerminalProcess.ToggleVisibility(_settings.Size, _settings.Position);
             }
         }
     }

--- a/WinTermPlus/UI/Views/ConfigView.xaml
+++ b/WinTermPlus/UI/Views/ConfigView.xaml
@@ -11,8 +11,9 @@
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
-        <Grid Margin="20">
+        <Grid Margin="10" UseLayoutRounding="False">
             <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
@@ -24,8 +25,8 @@
                 <CheckBox.LayoutTransform>
                     <ScaleTransform ScaleX="1.2" ScaleY="1.2" />
                 </CheckBox.LayoutTransform>
-            </CheckBox> 
-            
+            </CheckBox>
+
             <CheckBox Grid.Row="1"
                       Content="Quake Mode (CTRL + ~)" 
                       x:Name="QuakeMode"
@@ -40,6 +41,8 @@
                   Visibility="{Binding QuakeMode, Converter={StaticResource BooleanToVisibilityConverter}}">
 
                 <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
@@ -59,11 +62,11 @@
                 <Slider  Grid.Row="0" Grid.Column="1"
                          x:Name="Width"
                          VerticalAlignment="Bottom"
-                         Minimum="1" Maximum="100" 
+                         Minimum="1" Maximum="120"
                          Interval="1"/>
 
                 <StackPanel Grid.Row="1"
-                            Margin="0 10 0 0"
+                            Margin="0 8 0 0"
                             Orientation="Horizontal"
                             HorizontalAlignment="Right">
                     <Label Margin="0" Padding="0" Content="Height: " />
@@ -74,14 +77,42 @@
                           x:Name="Height"
                           Interval="1"
                           VerticalAlignment="Bottom"
-                          Minimum="1" Maximum="100" />
+                          Minimum="1" Maximum="120" />
+
+                <StackPanel Grid.Row="2"
+                            Margin="0 8 0 0"
+                            Orientation="Horizontal"
+                            HorizontalAlignment="Right">
+                    <Label Margin="0" Padding="0" Content="X Offset: "/>
+                    <Label Margin="0" Padding="0" Content="{Binding PositionX}" />
+                    <Label Margin="0" Padding="0" Content="" />
+                </StackPanel>
+                <Slider  Grid.Row="2" Grid.Column="1"
+                         x:Name="PositionX"
+                         VerticalAlignment="Bottom"
+                         Minimum="-100" Maximum="100" 
+                         Interval="1" SmallChange="0"/>
+
+                <StackPanel Grid.Row="3"
+                            Margin="0,8,0,0"
+                            Orientation="Horizontal"
+                            HorizontalAlignment="Right">
+                    <Label Margin="0" Padding="0" Content="Y Offset: "/>
+                    <Label Margin="0" Padding="0" Content="{Binding PositionY}" />
+                    <Label Margin="0" Padding="0" Content="" />
+                </StackPanel>
+                <Slider Grid.Row="3" Grid.Column="1"
+                          x:Name="PositionY"
+                          Interval="1"
+                          VerticalAlignment="Bottom"
+                          Minimum="-100" Maximum="100" SmallChange="0" />
             </Grid>
         </Grid>
 
         <Button Grid.Row="1" 
                 HorizontalAlignment="Right" 
                 Padding="13 5"
-                Margin="20 0 20 10" 
+                Margin="20,5" 
                 x:Name="Done">Done</Button>
     </Grid>
 </Page>

--- a/WinTermPlus/WinTermPlus.csproj
+++ b/WinTermPlus/WinTermPlus.csproj
@@ -13,6 +13,21 @@
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <PublishUrl>publish\</PublishUrl>
+    <Install>true</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <UpdateEnabled>false</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateInterval>7</UpdateInterval>
+    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
+    <UpdatePeriodically>false</UpdatePeriodically>
+    <UpdateRequired>false</UpdateRequired>
+    <MapFileExtensions>true</MapFileExtensions>
+    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <UseApplicationTrust>false</UseApplicationTrust>
+    <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -83,6 +98,7 @@
       <SubType>Designer</SubType>
     </ApplicationDefinition>
     <Compile Include="Config.cs" />
+    <Compile Include="Infrastructure\WindowPosition.cs" />
     <Compile Include="Infrastructure\DelegateCommand.cs" />
     <Compile Include="Infrastructure\Percentage.cs" />
     <Compile Include="UI\Converters\RangeBaseToPercentageConverter.cs" />
@@ -152,6 +168,17 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Resource>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <BootstrapperPackage Include=".NETFramework,Version=v4.8">
+      <Visible>False</Visible>
+      <ProductName>Microsoft .NET Framework 4.8 %28x86 and x64%29</ProductName>
+      <Install>true</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1</ProductName>
+      <Install>false</Install>
+    </BootstrapperPackage>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
Hey @dotjosh,

For some reason, my Windows Terminal window is offset on my display by a few pixels on the positive X axis (leaving a gap between the left-side of the screen and the terminal window). I tried the new _initialPosition_ property in the Windows Terminal profile.json config; however, negative values are not working, so I thought it would be cool to make my first open-source contribution to your project, allowing the user to offset the window on the X and Y axes respectively.

Lastly, when I set the width to 100%, the terminal window fills about 98% of my screen, so I increased the maximum width and height to 120% (from 100%).

Please feel free to let me know if there is anything you would like changed in the PR. Thank you.

**Additions**

- Add configuration: 'X Offset' and 'Y Offset' with min value of -100 and max value of 100
-Change configuration: 'Width' and 'Height' max values from 100% to 120%
- Tweak UI to accomodate two additional rows (existing UI config cut off the last row)

**Known issues:**

  -When the terminal is first displayed, you must hide/show it for it to repaint with the new position configuration
-If you create a new terminal tab that is different than the previous terminal, it will break the show/hide functionality. (profiles are set in Windows Terminal profile.json) - i.e. You open the terminal, which loads Ubuntu, and then you create a Powershell tab - now the show/hide functionality is broken